### PR TITLE
fixes issues with MemoryModule function

### DIFF
--- a/pythonmemorymodule/__init__.py
+++ b/pythonmemorymodule/__init__.py
@@ -768,9 +768,12 @@ class MemoryModule(pe.PE):
 			
 				funcref = cast(funcrefaddr, PFARPROC)
 				if entry_imports[j].import_by_ordinal == True: 
-					importordinal= entry_imports[j].ordinal.decode('utf-8')  
+					if 'decode' in dir(entry_imports[j].ordinal):
+						importordinal= entry_imports[j].ordinal.decode('utf-8')
+					else:
+						importordinal= entry_imports[j].ordinal
 					self.dbg('Found import ordinal entry, %s', cast(importordinal, LPCSTR))
-					funcref.contents = GetProcAddress(hmod, importordinal)
+					funcref.contents = GetProcAddress(hmod, cast(importordinal, LPCSTR))
 				else:
 					importname= entry_imports[j].name.decode('utf-8') 
 					self.dbg('Found import by name entry %s , at address 0x%x', importname, entry_imports[j].address)

--- a/pythonmemorymodule/pefile.py
+++ b/pythonmemorymodule/pefile.py
@@ -38,7 +38,7 @@ from hashlib import md5
 import functools
 import copy as copymod
 
-import pythonmemorymodule.ordlookup
+import pythonmemorymodule.ordlookup as ordlookup
 
 codecs.register_error("backslashreplace_", codecs.lookup_error("backslashreplace"))
 


### PR DESCRIPTION
This is related to #1, caused by in invalid function reference in pefile, and also some string type issues, when running in python 3.10. This imports pythonmemorymodule.ordlookup as ordlookup to address the first issue. For the second, I added a check to see if ordinal had the decode method, and only attempts decode if it does. Then I added an explicit cast to LPCSTR, which should allow compatibility regardless of the value types are returned by importordinal.